### PR TITLE
Add file test for IGNORE_GLOBAL_HOOKS

### DIFF
--- a/hooks/_local-hook-exec
+++ b/hooks/_local-hook-exec
@@ -9,6 +9,9 @@ if [ -e $LOCAL_HOOK ]; then
     $LOCAL_HOOK
 fi
 
-if cat "${IGNORE_GLOBAL_HOOKS}" | grep -q "${GIT_ROOT}"; then
-    exit 0
+if [ -f "${IGNORE_GLOBAL_HOOKS}" ]
+then
+    if cat "${IGNORE_GLOBAL_HOOKS}" | grep -q "${GIT_ROOT}"; then
+        exit 0
+    fi
 fi


### PR DESCRIPTION
This change will add a file check test for the IGNORE_GLOBAL_HOOKS
variable.  This will prevent an error from the subsequent `cat` command
if the file does not exist.  The error from `cat` is innocuous, but
suppressing it will reduce any confusion for users who see an error in
the commit messages should the file IGNORE_GLOBAL_HOOKS not exist.