### PR TITLE
Check only staged file contents.

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,17 +1,27 @@
 #!/bin/bash
 
 source `dirname ${0}`/_local-hook-exec
-declare scriptDir=$(cd $(dirname $0);pwd)
-declare parentDir="$(dirname "${scriptDir}")"
 declare FILES=$(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g')
 [ -z "$FILES" ] && exit 0
 echo "  ▶ Check credentials by secretlint"
-# Secretlint all selected files
-echo "$FILES" | xargs docker run -v `pwd`:`pwd` -w `pwd` --rm secretlint/secretlint secretlint
+declare TEMPDIR=$(mktemp -d)
+trap 'rm -rf -- "$TEMPDIR"' EXIT
+# Secretlint all staged files
+echo "$FILES" | while read -r filePath
+do
+    declare fileDir="$TEMPDIR"/$(dirname "$filePath")
+    if [ ! -d "$fileDir" ]
+    then
+        mkdir -p "$fileDir"
+    fi
+    git show :"$filePath" > "$TEMPDIR/$filePath"
+done
+docker run \
+    --mount type=bind,source="$TEMPDIR",target=$(pwd) \
+    --workdir $(pwd) --rm secretlint/secretlint secretlint '**/*'
 RET=$?
 if [ $RET -eq 0 ] ;then
     exit 0
 else
     exit 1
 fi
-


### PR DESCRIPTION
People sometimes need to write credentials directly into source codes, such as when maintaining legacy codes.

After you've done with that, carefully picked and staged necessary changes you want, you might only want to inspect what you'd decided to commit.

This change increases disc usage, since `git show` give you results via stdout, and we have to save them for checking with secretlint.
https://github.com/secretlint/secretlint/issues/357 might be related with this issue.
