### PR TITLE
Fix pre-commit hook failure with filenames containing spaces

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 source `dirname ${0}`/_local-hook-exec
-declare FILES=$(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g')
+declare FILES=$(git diff --cached --name-only --diff-filter=ACMR)
 [ -z "$FILES" ] && exit 0
 echo "  ▶ Check credentials by secretlint"
 declare TEMPDIR=$(mktemp -d)
 trap 'rm -rf -- "$TEMPDIR"' EXIT
 # Secretlint all staged files
-echo "$FILES" | while read -r filePath
+echo "$FILES" | while IFS= read -r filePath
 do
     declare fileDir="$TEMPDIR"/$(dirname "$filePath")
     if [ ! -d "$fileDir" ]


### PR DESCRIPTION
## Issue
This pre-commit hook fails when a filename contains spaces.
The error occurs at the following line:

[hooks/pre-commit#L17](https://github.com/secretlint/git-hooks/blob/2e93e3656161efb0ca7b488f96def1fe6428d339/hooks/pre-commit#L17)

## Steps to reproduce

1. Create a file with spaces in the name:

```sh
❯ tree .
.
└── secret file.env
```

2. Stage the file:

```sh
❯ git status
On branch main

No commits yet

Changes to be committed:
  (use "git rm --cached <file>..." to unstage)
        new file:   secret file.env
```

3. Try to commit:

```sh
❯ git commit
  ▶ Check credentials by secretlint
fatal: path 'secret\ file.env' does not exist (neither on disk nor in the index)
Error: ENOENT: no such file or directory, open '/Users/hyuga/ws/secret-lint-hooks-error/secret/ file.env'
    at async open (node:internal/fs/promises:639:25)
    at async Object.readFile (node:internal/fs/promises:1246:14)
    at async createRawSource (file:///usr/local/lib/node_modules/secretlint/node_modules/@secretlint/source-creator/module/index.js:17:21)
    at async lintFile (file:///usr/local/lib/node_modules/secretlint/node_modules/@secretlint/node/module/index.js:15:23)
    at async mapper (file:///usr/local/lib/node_modules/secretlint/node_modules/@secretlint/node/module/index.js:63:24)
    at async /usr/local/lib/node_modules/secretlint/node_modules/p-map/index.js:57:22 {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/Users/hyuga/ws/secret-lint-hooks-error/secret/ file.env'
}
```
## Cause

The issue is caused by unnecessary escape processing in the following line:

[hooks/pre-commit#L4](https://github.com/secretlint/git-hooks/blob/2e93e3656161efb0ca7b488f96def1fe6428d339/hooks/pre-commit#L4)

- The escape handling modifies filenames, causing git show to receive an incorrect path.
- Example of the incorrect behavior:

```sh
❯ git show :"secret/ file.env"
fatal: path 'secret/ file.env' does not exist (neither on disk nor in the index)

``` 

- The expected behavior

```sh
❯ git show :"secret file.env"
MYSECRET=HOGE
```

## Fix

- Instead of using `sed` to escape spaces, keep the raw input.
Use `IFS=` inside `while` to ensure filenames are read as a single string.

This prevents unintended filename modification and allows git show to work correctly.